### PR TITLE
release 1.3.2

### DIFF
--- a/services/maiev-base/app/common/tests/test_utils.py
+++ b/services/maiev-base/app/common/tests/test_utils.py
@@ -18,7 +18,7 @@ class TestImageVersion(TestCase):
         :return:
         """
         iv = self.create_iv(*hints)
-        self.assertEqual({k: v for k, v in iv.data.items() if k in result}, result)
+        self.assertEqual(result, {k: v for k, v in iv.data.items() if k in result})
 
     def create_iv(self, *hints):
         final_hints = {
@@ -71,6 +71,10 @@ class TestImageVersion(TestCase):
         self.assert_parsed_equal('overseer-1.0.69a1+build45', version="1.0.69a1+build45", species='overseer')
         self.assert_parsed_equal('overseer-1.0.69a1', version="1.0.69a1", species='overseer')
         self.assert_parsed_equal('overseer-1.0.69+build43', version="1.0.69+build43", species='overseer')
+
+    def test_detect_composed_species(self):
+        # specific
+        self.assert_parsed_equal('load_manager-release-1.3.1', version='1.3.1', species='load_manager-release')
 
     def test_full_parse(self):
         self.assert_parsed_equal('alpine', 'python', 'localhost', version=None, image='python',

--- a/services/maiev-base/app/common/utils.py
+++ b/services/maiev-base/app/common/utils.py
@@ -2,8 +2,8 @@
 
 import datetime
 import logging
-import re
 import types
+import regex
 from functools import partial, wraps
 
 import eventlet
@@ -133,7 +133,7 @@ class ImageVersion(object):
 
     """
     _VERSION_REGEXP = r'(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:([0-9a-zA-Z.]*))?(?:\+([0-9a-zA-Z.]*))?'
-    tag_regex = re.compile('^((?P<version>%s|latest)|-|(?P<species>[a-zA-Z_]+))+$' % _VERSION_REGEXP)
+    tag_regex = regex.compile('^((?P<version>%s|latest)|-|(?P<species>[a-zA-Z_]+))+$' % _VERSION_REGEXP)
     """
     the rexexp to parse the tage: see https://regex101.com/r/o2hr5V/3
     """
@@ -185,7 +185,10 @@ class ImageVersion(object):
         if tag is not None:
             parsed_raw = cls.tag_regex.match(tag)
             if parsed_raw:
-                result.update(parsed_raw.groupdict())
+                result.update({
+                    k: '-'.join(v)
+                    for k, v in parsed_raw.capturesdict().items()}
+                )
         return result
 
     def is_same_image(self, other):


### PR DESCRIPTION
add the support of version with «release-» prefix, which will be parsed in the specs instead of the version.

version bump